### PR TITLE
fixes #16 - do not re-encode url query

### DIFF
--- a/web_src/src/services/PlaylistService.ts
+++ b/web_src/src/services/PlaylistService.ts
@@ -1,22 +1,22 @@
 
 export async function searchPlaylist(query: string): Promise<SpotifyApi.PlaylistObjectSimplified[]> {
-    // generates URLSearchParams
-    var searchParams = new URLSearchParams();
-    searchParams.set("q", encodeURI(query));
-    searchParams.set("type", "playlist");
-    // call API with full URL
-    var fullURL: string = makeURL("/playlists/?", searchParams);
-    const response = await http.get(fullURL);
-    // extracts playlists from response
-    const body: SpotifyApi.PlaylistSearchResponse = await response.json();
-    let playlists: SpotifyApi.PlaylistObjectSimplified[] = body.playlists.items
-    return playlists;
+  // generates URLSearchParams
+  var searchParams = new URLSearchParams();
+  searchParams.set("q", query);
+  searchParams.set("type", "playlist");
+  // call API with full URL
+  var fullURL: string = makeURL("/playlists/?", searchParams);
+  const response = await http.get(fullURL);
+  // extracts playlists from response
+  const body: SpotifyApi.PlaylistSearchResponse = await response.json();
+  let playlists: SpotifyApi.PlaylistObjectSimplified[] = body.playlists.items
+  return playlists;
 }
 
 const http = {
-    async get(url: string) {
-        return await fetch(url);
-    }
+  async get(url: string) {
+    return await fetch(url);
+  }
 }
 
 export async function getPlaylist(id: string): Promise<SpotifyApi.PlaylistObjectFull> {
@@ -32,5 +32,5 @@ export async function getPlaylist(id: string): Promise<SpotifyApi.PlaylistObject
 
 // Returns a full URL (Ex: http://localhost:8080/playlists/?q="hello"&type=playlist)
 function makeURL(prefix: string, searchParams: URLSearchParams): string {
-    return "http://localhost:8080" + prefix + searchParams.toString();
+  return "http://localhost:8080" + prefix + searchParams.toString();
 }


### PR DESCRIPTION
When converting a string query into a URLSearchParams object, do not re-encode the URL.