### PR TITLE
Add login/create account endpoint

### DIFF
--- a/backend_src/README.md
+++ b/backend_src/README.md
@@ -7,7 +7,7 @@
 
 ## How to Develop
 - Add CLIENT_ID and CLIENT_SECRET to your environment
-- Add REDIRECT_URI to your environment (should be 'http://localhost:9000/' locally
+- Add REDIRECT_URI to your environment (should be 'http://localhost:9000' locally
 - `yarn install` and `yarn run dev` in /backend_src/ will operate both services at the same time
 ``` sh
 yarn install

--- a/backend_src/README.md
+++ b/backend_src/README.md
@@ -7,6 +7,7 @@
 
 ## How to Develop
 - Add CLIENT_ID and CLIENT_SECRET to your environment
+- Add REDIRECT_URI to your environment (should be 'http://localhost:9000/' locally
 - `yarn install` and `yarn run dev` in /backend_src/ will operate both services at the same time
 ``` sh
 yarn install

--- a/backend_src/http_api/app.js
+++ b/backend_src/http_api/app.js
@@ -1,4 +1,6 @@
 const express = require('express');
+const session = require('express-session');
+const MongoStore = require('connect-mongo')(session);
 const db = require('./db.js');
 const cors = require('cors');
 const bodyParser = require('body-parser');
@@ -6,10 +8,22 @@ const playlistRouter = require('./routes/playlists');
 const userRouter = require('./routes/users');
 const auth = require('./auth');
 
-const app = express();
 
-app.use(cors());
+const app = express();
+app.use(cors({
+  origin: process.env.REDIRECT_URI,
+  credentials: true
+}));
 app.use(bodyParser.json());
+
+// Session store
+app.use(session({
+  cookie: { maxAge: 60000 },
+  resave: false,
+  saveUninitialized: true,
+  secret: process.env.CLIENT_SECRET,
+  store: new MongoStore({ url: process.env.MONGODB_URI })
+}));
 
 app.get('/', (req, res) => {
   res.set('Content-Type', 'text/html');

--- a/backend_src/http_api/app.js
+++ b/backend_src/http_api/app.js
@@ -1,12 +1,15 @@
 const express = require('express');
 const db = require('./db.js');
 const cors = require('cors');
+const bodyParser = require('body-parser');
 const playlistRouter = require('./routes/playlists');
 const userRouter = require('./routes/users');
+const auth = require('./auth');
 
 const app = express();
 
 app.use(cors());
+app.use(bodyParser.json());
 
 app.get('/', (req, res) => {
   res.set('Content-Type', 'text/html');
@@ -17,6 +20,7 @@ app.get('/', (req, res) => {
 
 app.use('/playlists', playlistRouter);
 app.use('/users', userRouter);
+app.use('/auth-spotify', auth.spotifyAuthEndpoint);
 
 db.connect(process.env.MONGODB_URI, (err) => {
   if (err) throw err;

--- a/backend_src/http_api/auth.js
+++ b/backend_src/http_api/auth.js
@@ -20,7 +20,7 @@ const getToken = async () => {
   return access_token;
 }
 
-const refreshAccessToken = async (refresh_token) => {
+const refreshAccessToken = async (refresh_token_old) => {
   const { data: { access_token, refresh_token } } = await axios({
     url: 'https://accounts.spotify.com/api/token',
     method: 'post',
@@ -30,7 +30,7 @@ const refreshAccessToken = async (refresh_token) => {
     },
     params: {
       grant_type: 'refresh_token',
-      refresh_token
+      refresh_token: refresh_token_old
     },
   });
   return { access_token, refresh_token };

--- a/backend_src/http_api/auth.js
+++ b/backend_src/http_api/auth.js
@@ -95,7 +95,7 @@ spotifyAuthEndpoint.post('/', async (req, res, next) => {
         spotifyId: id,
         refreshToken: refresh_token,
         accessToken: access_token,
-        fiends: [],
+        friends: [],
         playlists: [],
         favoriteTracks: [],
         favoriteArtists: [],

--- a/backend_src/http_api/auth.js
+++ b/backend_src/http_api/auth.js
@@ -1,9 +1,11 @@
 const axios = require('axios');
+const express = require('express');
+
 
 const CLIENT_ID = process.env.CLIENT_ID;
 const CLIENT_SECRET = process.env.CLIENT_SECRET;
 
-module.exports = async () => {
+const getToken = async () => {
   const { data: { access_token } } = await axios({
     url: 'https://accounts.spotify.com/api/token',
     method: 'post',
@@ -15,4 +17,65 @@ module.exports = async () => {
     },
   });
   return access_token;
+}
+
+const getUserAccessKeys = async (code) => {
+  const { data: { access_token, refresh_token } } = await axios({
+    url: 'https://accounts.spotify.com/api/token',
+    method: 'post',
+    headers: {
+      'Authorization': 'Basic ' + Buffer.from(CLIENT_ID + ':' + CLIENT_SECRET).toString('base64'),
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    params: {
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: process.env.REDIRECT_URI
+    },
+  });
+  return { access_token, refresh_token };
+}
+
+const getSpotifyMe = async (access_token) => {
+  const { data } = await axios({
+    url: 'https://api.spotify.com/v1/me',
+    headers: {
+      'Authorization': 'Bearer ' + access_token,
+    }
+  });
+  return data;
+}
+
+const spotifyAuthEndpoint = new express.Router;
+
+spotifyAuthEndpoint.post('/', async (req, res, next) => {
+  const {
+    code
+  } = req.body;
+
+  try {
+    const {
+      access_token,
+      refresh_token
+    } = await getUserAccessKeys(code);
+
+    // TODO Store these in user model
+
+    const {
+      display_name, 
+      id
+    } = await getSpotifyMe(access_token);
+    res.json({ name: display_name });
+  } catch (exception) {
+    console.log(exception);
+    res.status(400).json({error: 'Could not auth'});
+    return;
+  }
+});
+
+
+module.exports = {
+  getToken,
+  getUserAccessKeys,
+  spotifyAuthEndpoint
 };

--- a/backend_src/http_api/auth.js
+++ b/backend_src/http_api/auth.js
@@ -20,6 +20,22 @@ const getToken = async () => {
   return access_token;
 }
 
+const refreshAccessToken = async (refresh_token) => {
+  const { data: { access_token, refresh_token } } = await axios({
+    url: 'https://accounts.spotify.com/api/token',
+    method: 'post',
+    headers: {
+      'Authorization': 'Basic ' + Buffer.from(CLIENT_ID + ':' + CLIENT_SECRET).toString('base64'),
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    params: {
+      grant_type: 'refresh_token',
+      refresh_token
+    },
+  });
+  return { access_token, refresh_token };
+}
+
 const getUserAccessKeys = async (code) => {
   const { data: { access_token, refresh_token } } = await axios({
     url: 'https://accounts.spotify.com/api/token',

--- a/backend_src/http_api/db.js
+++ b/backend_src/http_api/db.js
@@ -2,6 +2,7 @@ const { MongoClient } = require('mongodb');
 
 const state = {
   db: null,
+  client: null
 };
 
 exports.connect = (url, done) => {
@@ -9,15 +10,18 @@ exports.connect = (url, done) => {
 
   MongoClient.connect(url, { useUnifiedTopology: true }, (err, client) => {
     if(err) return done(err);
-    // The name of the database is the username in the mongodb URI
-    const dbName = process.env.MONGODB_URI.split('mongodb://').pop().split(':')[0];
+    const dbName = process.env.MONGODB_URI.split('mongodb://').pop().split('/')[1];
     state.db = client.db(dbName);
+    state.client = client;
     done();
   });
 };
 
 exports.get = () => {
   return state.db;
+};
+exports.getClient = () => {
+  return state.client;
 };
 
 exports.close = (done) => {

--- a/backend_src/http_api/package.json
+++ b/backend_src/http_api/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
+    "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "mongodb": "^3.5.5"

--- a/backend_src/http_api/package.json
+++ b/backend_src/http_api/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "axios": "^0.19.2",
     "body-parser": "^1.19.0",
+    "connect-mongo": "^3.2.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "express-session": "^1.17.0",
     "mongodb": "^3.5.5"
   },
   "workspaces": {

--- a/backend_src/http_api/routes/playlists.js
+++ b/backend_src/http_api/routes/playlists.js
@@ -4,7 +4,6 @@ const auth = require('../auth');
 const cors = require('cors');
 
 const router = new express.Router;
-router.use(cors());
 
 router.get('/', async (req, res) => {
   const token = await auth.getToken();

--- a/backend_src/http_api/routes/playlists.js
+++ b/backend_src/http_api/routes/playlists.js
@@ -1,13 +1,13 @@
 const express = require('express');
 const axios = require('axios');
-const getToken = require('../auth');
+const auth = require('../auth');
 const cors = require('cors');
 
 const router = new express.Router;
 router.use(cors());
 
 router.get('/', async (req, res) => {
-  const token = await getToken();
+  const token = await auth.getToken();
   // TODO: Parse req.query as JSON and validate it
   const query = req.originalUrl.split('\/', 3)[2];
 
@@ -25,7 +25,7 @@ router.get('/', async (req, res) => {
 });
 
 router.get('/:playlistId', async (req, res) => {
-  const token = await getToken();
+  const token = await auth.getToken();
   const { playlistId } = req.params;
 
   const { data } = await axios({

--- a/backend_src/http_api/routes/users.js
+++ b/backend_src/http_api/routes/users.js
@@ -3,7 +3,27 @@ const express = require('express');
 const cors = require('cors');
 
 const router = new express.Router;
-router.use(cors());
+
+router.get('/me', async (req, res) => {
+  const {
+    spotifyId
+  } = req.session;
+  if (!spotifyId) {
+    res.status(401).json({ error: 'Unauthenticated' })
+    return;
+  };
+
+  const user = await db.get().collection('users').findOne({ spotifyId });
+
+  if (!user) {
+    return res.status(404).json(`User with id ${userId} not found...`).send();
+  }
+  // Dont surface access token and refresh token
+  delete user.accessToken;
+  delete user.refreshToken;
+
+  return res.json(user);
+});
 
 router.get('/:userId', async (req, res) => {
   const { userId } = req.params;

--- a/backend_src/yarn.lock
+++ b/backend_src/yarn.lock
@@ -35,7 +35,7 @@ bluebird@3.5.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
   integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
-body-parser@1.19.0:
+body-parser@1.19.0, body-parser@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==

--- a/backend_src/yarn.lock
+++ b/backend_src/yarn.lock
@@ -61,6 +61,13 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
+connect-mongo@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/connect-mongo/-/connect-mongo-3.2.0.tgz#20f776c7f2a9d8144fc76cfdcbf33edb05eb4d52"
+  integrity sha512-0Mx88079Z20CG909wCFlR3UxhMYGg6Ibn1hkIje1hwsqOLWtL9HJV+XD0DAjUvQScK6WqY/FA8tSVQM9rR64Rw==
+  dependencies:
+    mongodb "^3.1.0"
+
 content-disposition@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
@@ -120,6 +127,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -144,6 +156,20 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+express-session@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.0.tgz#9b50dbb5e8a03c3537368138f072736150b7f9b3"
+  integrity sha512-t4oX2z7uoSqATbMfsxWMbNjAL0T5zpvcJCk3Z9wnPPN7ibddhnmDZXHfEcoBMG2ojKXZoCyPMc5FbtK+G7SoDg==
+  dependencies:
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-headers "~1.0.2"
+    parseurl "~1.3.3"
+    safe-buffer "5.2.0"
+    uid-safe "~2.1.5"
 
 express@^4.17.1:
   version "4.17.1"
@@ -302,7 +328,7 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mongodb@3.5.5, mongodb@^3.5.5:
+mongodb@3.5.5, mongodb@^3.1.0, mongodb@^3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.5.5.tgz#1334c3e5a384469ac7ef0dea69d59acc829a496a"
   integrity sha512-GCjDxR3UOltDq00Zcpzql6dQo1sVry60OXJY3TDmFc2SWFY6c8Gn1Ardidc5jDirvJrx2GC3knGOImKphbSL3A==
@@ -385,6 +411,11 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
+
 parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -412,6 +443,11 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+random-bytes@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/random-bytes/-/random-bytes-1.0.0.tgz#4f68a1dc0ae58bd3fb95848c30324db75d64360b"
+  integrity sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -464,7 +500,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.1.1, safe-buffer@^5.1.2:
+safe-buffer@5.2.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
@@ -561,6 +597,13 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+uid-safe@~2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/uid-safe/-/uid-safe-2.1.5.tgz#2b3d5c7240e8fc2e58f8aa269e5ee49c0857bd3a"
+  integrity sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==
+  dependencies:
+    random-bytes "~1.0.0"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/web_src/README.md
+++ b/web_src/README.md
@@ -13,6 +13,7 @@ yarn install
 yarn run dev
 
 ```
+Add `SPOTIFY_CLIENT_ID` to environment variables
 
 ### Types
 


### PR DESCRIPTION
Adds /spotify-auth/ endpoint. This endpoint will take an access code from the client Oauth flow (implemented in https://github.com/jack-michaud/partify/tree/issue/9)

/spotiffy-auth/ will take the code and get an access token and refresh token from Spotify. It then gets basic user information from the spotify API about that user (display name, spotifyId). If that user does not exist in our database, we create a new entry for that user. 
The session variable spotifyId is then set for the user so other requests can use that info. 
The `/users/me` endpoint demonstrates that usage.

Usage changes:
- We now need to specify REDIRECT_URI in the back end environment variables. The spotify auth endpoints require it on the backend too https://developer.spotify.com/documentation/general/guides/authorization-guide/
- The db driver will now correctly find the database name from the MONGODB_URI -- @MichaelBond24 It was using the username field for the database name -- that won't work in production D: 
- Added `refreshAccessToken` function so we can refresh the access tokens if necessary for protected Spotify API calls.