### PR TITLE
Add account login and profile page stub

### DIFF
--- a/backend_src/http_api/app.js
+++ b/backend_src/http_api/app.js
@@ -18,7 +18,10 @@ app.use(bodyParser.json());
 
 // Session store
 app.use(session({
-  cookie: { maxAge: 1000 * 60 * 60 * 24 },
+  cookie: { 
+    maxAge: 1000 * 60 * 60 * 24,
+    secure: 'auto'
+  },
   resave: false,
   saveUninitialized: true,
   secret: process.env.CLIENT_SECRET,

--- a/backend_src/http_api/app.js
+++ b/backend_src/http_api/app.js
@@ -18,7 +18,7 @@ app.use(bodyParser.json());
 
 // Session store
 app.use(session({
-  cookie: { maxAge: 60000 },
+  cookie: { maxAge: 1000 * 60 * 60 * 24 },
   resave: false,
   saveUninitialized: true,
   secret: process.env.CLIENT_SECRET,

--- a/backend_src/http_api/auth.js
+++ b/backend_src/http_api/auth.js
@@ -20,6 +20,22 @@ const getToken = async () => {
   return access_token;
 }
 
+const refreshAccessToken = async (refresh_token_old) => {
+  const { data: { access_token, refresh_token } } = await axios({
+    url: 'https://accounts.spotify.com/api/token',
+    method: 'post',
+    headers: {
+      'Authorization': 'Basic ' + Buffer.from(CLIENT_ID + ':' + CLIENT_SECRET).toString('base64'),
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    params: {
+      grant_type: 'refresh_token',
+      refresh_token: refresh_token_old
+    },
+  });
+  return { access_token, refresh_token };
+}
+
 const getUserAccessKeys = async (code) => {
   const { data: { access_token, refresh_token } } = await axios({
     url: 'https://accounts.spotify.com/api/token',

--- a/web_src/src/components/LoginComponent.tsx
+++ b/web_src/src/components/LoginComponent.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const LoginComponent = () => {
+  return (
+    <div>
+      <a href={`https://accounts.spotify.com/authorize?client_id=${process.env.SPOTIFY_CLIENT_ID}&scope=user-read-playback-state user-modify-playback-state user-read-currently-playing playlist-read-collaborative playlist-modify-public playlist-read-private&response_type=code&redirect_uri=${document.location.origin}/`}>
+        Log In
+      </a>
+    </div>
+  );
+}
+
+export default LoginComponent;

--- a/web_src/src/components/NavbarComponent.tsx
+++ b/web_src/src/components/NavbarComponent.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Navbar from 'src/containers/Navbar';
+
+import { Profile } from '../types';
+
+interface IProps {
+  isLoggedIn: boolean;
+  profile?: Profile;
+}
+
+const NavbarComponent = (props: IProps) => {
+  return (
+    <div className="w-full h-10 bg-purple-900">
+      { props.isLoggedIn != null && 
+        <div>
+          {
+            props.isLoggedIn ? 
+            <Link to={"/profile"}>Profile</Link> :
+            <Link to={"/login"}>Log In</Link>
+          }
+        </div>
+      }
+    </div>
+  );
+}
+
+export default NavbarComponent;

--- a/web_src/src/components/ProfileComponent.tsx
+++ b/web_src/src/components/ProfileComponent.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { Profile } from '../types';
+
+interface IProps {
+  profile: Profile;
+}
+
+const ProfileComponent = (props: IProps) => {
+  return (
+    <div>
+      { JSON.stringify(props.profile) }
+    </div>
+  )
+}
+
+export default ProfileComponent;

--- a/web_src/src/containers/App.tsx
+++ b/web_src/src/containers/App.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import SearchPageContainer from './SearchPageContainer';
 import PlaylistDetailContainer from "./PlaylistDetailContainer";
+import Login from './Login';
+import Profile from './Profile';
+
+import Navbar from '../containers/Navbar';
 
 import {
   BrowserRouter as Router,
@@ -14,7 +18,14 @@ const App = () => {
 
   return (
     <Router>
+      <Navbar />
       <Switch>
+        <Route path="/profile">
+          <Profile />
+        </Route>
+        <Route path="/login">
+          <Login />
+        </Route>
         <Route path="/playlist/:playlistId">
           <PlaylistDetailContainer />
         </Route>

--- a/web_src/src/containers/Login.tsx
+++ b/web_src/src/containers/Login.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const Login = () => {
+  return (
+    <div>
+      <a href={`https://accounts.spotify.com/authorize?client_id=${process.env.SPOTIFY_CLIENT_ID}&scope=user-read-playback-state user-modify-playback-state user-read-currently-playing playlist-read-collaborative playlist-modify-public playlist-read-private&response_type=code&redirect_uri=${document.location.origin}/`}>
+        Log In
+      </a>
+    </div>
+  );
+}
+
+export default Login;
+
+

--- a/web_src/src/containers/Login.tsx
+++ b/web_src/src/containers/Login.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
+import LoginComponent from '../components/LoginComponent';
+
 const Login = () => {
   return (
-    <div>
-      <a href={`https://accounts.spotify.com/authorize?client_id=${process.env.SPOTIFY_CLIENT_ID}&scope=user-read-playback-state user-modify-playback-state user-read-currently-playing playlist-read-collaborative playlist-modify-public playlist-read-private&response_type=code&redirect_uri=${document.location.origin}/`}>
-        Log In
-      </a>
-    </div>
+    <>
+      <LoginComponent />
+    </>
   );
 }
 

--- a/web_src/src/containers/Navbar.tsx
+++ b/web_src/src/containers/Navbar.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation, useHistory } from 'react-router-dom';
+import { logInAction, fetchProfile } from '../store/profile/actions';
+import { isLoggedInSelector, profileSelector } from '../store/profile/selectors';
+import NavbarComponent from '../components/NavbarComponent';
+
+const Navbar = () => {
+  const location = useLocation();
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  // Log In if there is a code
+  useEffect(() => {
+    console.log(location)
+    const params = new URLSearchParams(location.search);
+    const code = params.get('code')
+    const error = params.get('error')
+
+    if (code) {
+      dispatch(logInAction(code));
+      // Clears out the code from the URL params.
+      history.push({});
+    } else if (error) {
+      console.error('Unable to authenticate. Error: ' + error); 
+    }
+  }, [location]);
+
+  // Just get profile information on mount.
+  // Maybe you're already logged in.
+  useEffect(() => {
+    dispatch(fetchProfile());
+  }, []);
+
+
+  const profile = useSelector(profileSelector);
+  const isLoggedIn = useSelector(isLoggedInSelector);
+
+  return (
+    <>
+      <NavbarComponent
+        isLoggedIn={isLoggedIn}
+        profile={profile} />
+    </>
+  );
+}
+
+export default Navbar;

--- a/web_src/src/containers/Profile.tsx
+++ b/web_src/src/containers/Profile.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { 
+  profileSelector,
+  isLoggedInSelector
+} from '../store/profile/selectors';
+
+import ProfileComponent from '../components/ProfileComponent';
+
+const Profile = () => {
+
+  const profile = useSelector(profileSelector);
+
+  return (
+    <>
+      <ProfileComponent profile={profile} />
+    </>
+  );
+}
+export default Profile;

--- a/web_src/src/services/LoginService.ts
+++ b/web_src/src/services/LoginService.ts
@@ -1,0 +1,26 @@
+
+export const sendCode = async (code: string): Promise<void> => {
+  const resp = await fetch(process.env.API_URL + '/auth-spotify', {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      code
+    })
+  })
+  if (resp.status != 200) {
+    throw 'Unable to authenticate';
+  }
+}
+
+export const fetchMe = async () => {
+  const resp = await fetch(process.env.API_URL + '/users/me', {
+    credentials: 'include',
+  });
+  if (resp.status != 200) {
+    throw 'Unable to authenticate';
+  }
+  return await resp.json();
+}

--- a/web_src/src/store/profile/actions.ts
+++ b/web_src/src/store/profile/actions.ts
@@ -4,18 +4,20 @@ import {
   ThunkActionType
 } from '../../types';
 
+import { sendCode, fetchMe } from '../../services/LoginService';
+
 export const PROFILE_LOG_IN_REQUEST = 'PROFILE_LOG_IN_REQUEST';
 export const PROFILE_LOG_IN_SUCCESS = 'PROFILE_LOG_IN_SUCCESS';
 export const PROFILE_LOG_IN_FAILURE = 'PROFILE_LOG_IN_FAILURE';
 export const PROFILE_LOG_OUT = 'PROFILE_LOG_OUT';
 
-export const logInAction = (username: string, password: string): ThunkActionType<ProfileState> => async (dispatch) => {
+export const logInAction = (code: string): ThunkActionType<ProfileState> => async (dispatch) => {
   dispatch({
     type: PROFILE_LOG_IN_REQUEST
   })
   try {
-    // TODO Send log in to log in service
-    const profile: Profile = null;
+    await sendCode(code);
+    const profile: Profile = await fetchMe();
     dispatch({
       type: PROFILE_LOG_IN_SUCCESS,
       payload: profile
@@ -26,7 +28,21 @@ export const logInAction = (username: string, password: string): ThunkActionType
       payload: e
     })
   }
+}
 
+export const fetchProfile = (): ThunkActionType<ProfileState> => async (dispatch) => {
+  try {
+    const profile: Profile = await fetchMe();
+    dispatch({
+      type: PROFILE_LOG_IN_SUCCESS,
+      payload: profile
+    })
+  } catch (e) {
+    dispatch({
+      type: PROFILE_LOG_IN_FAILURE,
+      payload: e
+    })
+  }
 }
 
 export const logOutAction = (): ThunkActionType<ProfileState> => async (dispatch) => {

--- a/web_src/src/store/profile/reducers.ts
+++ b/web_src/src/store/profile/reducers.ts
@@ -7,7 +7,7 @@ import {
 
 const initialState: ProfileState = {
   profile: null,
-  loggedIn: false,
+  loggedIn: null,
   logInError: null
 }
 
@@ -22,10 +22,11 @@ const reducers = (state: ProfileState = initialState, action: ActionType): Profi
   if (action.type == PROFILE_LOG_IN_FAILURE) {
     return {
       ...state,
+      loggedIn: false,
       logInError: action.payload
     }
   }
-  if (action.type == PROFILE_LOG_IN_REQUEST) {}
+  if (action.type == PROFILE_LOG_IN_REQUEST) { return state; }
   if (action.type == PROFILE_LOG_IN_SUCCESS) {
     return {
       ...state,

--- a/web_src/src/types.ts
+++ b/web_src/src/types.ts
@@ -9,9 +9,26 @@ export interface PlaylistState {
   playlistDetailLoading: boolean;
 }
 
-export interface Profile {
+export interface BasicInfo {
   id: string;
+  name: string;
+  imageUrl: string;
 }
+
+
+export interface Profile {
+  _id: string;
+  name: string;
+  joined: string;
+  spotifyId: string;
+  friends: BasicInfo[];
+  playlists: BasicInfo[];
+  favoriteTracks: BasicInfo[];
+  favoriteArtists: BasicInfo[];
+  favoriteAlbums: BasicInfo[];
+  favoriteGenres: BasicInfo[];
+}
+
 export interface ProfileState {
   profile?: Profile;
   loggedIn: boolean;

--- a/web_src/webpack.config.common.js
+++ b/web_src/webpack.config.common.js
@@ -26,7 +26,8 @@ module.exports = {
     }),
     new MiniCssExtractPlugin(),
     new webpack.EnvironmentPlugin({
-      API_URL: 'http://localhost:8080'
+      API_URL: 'http://localhost:8080',
+      SPOTIFY_CLIENT_ID: null
     })
   ],
   module: {


### PR DESCRIPTION
Merges into #27 

- Adds navbar that does access code management and profile fetching
- Adds LoginService that sends access code to `/spotify-auth/` and fetches profile info from /users/me
- Adds basic login view. Just a link to spotify's login page
- Adds basic profile view. Just dumps the info from `/users/me`